### PR TITLE
Adds instructions on how to stop tracking the local_settings.py file

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,13 @@ The instructions below assume you are running Ubuntu 12.04 LTS.
         ./manage.py runserver
 
    Point your web browser to http://127.0.0.1:8000/
+
+### Additional notes:
+
+1. If you are contributing to the development of this project, please make sure changes you make to the `twobuntu/local_settings.py` file as described in Step 5 of the Installation Instructions are not committed along with the rest of your changes. To stop tracking it,
+
+		git update-index --assume-unchanged twobuntu/local_settings.py
+
+   To re-enable tracking on the file,
+
+		git update-index --no-assume-unchanged twobuntu/local_settings.py


### PR DESCRIPTION
The `twobuntu/local_settings.py` file should not be forgotten and added with the rest of the changes when pushing code upstream. Added instructions to avoid that as additional notes in the `README.md` file
