### PR TITLE
Fixes form so search button appears next to input box

### DIFF
--- a/twobuntu/templates/pages/index.html
+++ b/twobuntu/templates/pages/index.html
@@ -12,16 +12,16 @@
             {% include "accounts/fragment.html" %}
         </div>
         <div class="col-sm-4">
-            <div class="input-group">
-                <form action="{% url "articles:search" %}">
+            <form action="{% url "articles:search" %}">
+                <div class="input-group">
                     <input type="text" class="form-control" name="q" placeholder="Enter search terms...">
                     <span class="input-group-btn">
                         <button class="btn btn-default" type="submit">
                             <span class="fa fa-search"></span>
                         </button>
                     </span>
-                </form>
-            </div>
+                </div>
+            </form>
             <br>
             {% include "news/fragment.html" %}
             <div class="well">


### PR DESCRIPTION
So the search form looks like this now:

![screenshot from 2014-03-23 14 43 39](https://f.cloud.github.com/assets/618609/2492949/929c7b7a-b26b-11e3-9910-2b82c26aff97.png)
